### PR TITLE
Support conditionals on contribution pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ The attribute of the given element to be changed. One of:
 
 * 'display'
 * 'properties'
+* 'css'
+* 'html'
 * 'attributes'
 * 'value'
 * 'before'
@@ -210,6 +212,8 @@ For these values of [state-property], the possible [state-property] values are:
   * 'hide': The element will be hidden with jQuery().hide().
   * 'show': The element will be shown with jQuery().show().
 * 'properties': An associative array of properties, to be applied to the element with jQuery().prop().
+* 'css': An associative array of properties, to be applied to the element with jQuery().css().
+* 'html': An associative array of properties, to be applied to the element with jQuery().html().
 * 'attributes': An associative array of attributes, to be applied to the element with jQuery().attr().
 * 'value': The value to which the element (which should be a form field) will be set, using jQuery().val().
 * 'before': The element will be relocated before the element indicated by this jQuery selector, with jQuery().insertBefore().

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ $civicrm_setting['com.joineryhq.profcond']['com.joineryhq.profcond'] = array(
     ),
   ),
   'contribution' => array(
-    // Contribution pages are not yet supported.
   ),
 );
 

--- a/js/profcond.js
+++ b/js/profcond.js
@@ -92,6 +92,9 @@
     if (state.css) {
       el.css(state.css);
     }
+    if (state.html) {
+      el.html(state.html);
+    }
 
     if (typeof state.value != 'undefined') {
       el.val(state.value).change();

--- a/js/profcond.js
+++ b/js/profcond.js
@@ -191,8 +191,8 @@
   };
 
   var profcondInitializeRules = function profcondInitializeRules() {
-    for (var ruleName in CRM.vars.profcond.eventConfig) {
-      var rule = CRM.vars.profcond.eventConfig[ruleName];
+    for (var ruleName in CRM.vars.profcond.pageConfig) {
+      var rule = CRM.vars.profcond.pageConfig[ruleName];
       var ruleClass = 'profcond-has-rule_' + ruleName;
       for (var conditionType in rule.conditions) {
         var conditions = rule.conditions[conditionType];
@@ -243,8 +243,8 @@
   cj("#priceset [price]").addClass('profcond-price-element');
 
   // Apply default state on page load.
-  if (CRM.vars.profcond.eventConfig.onload) {
-    profcondApplyStates(CRM.vars.profcond.eventConfig.onload);
+  if (CRM.vars.profcond.pageConfig.onload) {
+    profcondApplyStates(CRM.vars.profcond.pageConfig.onload);
   }
 
   profcondInitializeRules();

--- a/profcond.php
+++ b/profcond.php
@@ -10,14 +10,24 @@ use CRM_Profcond_ExtensionUtil as E;
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_buildForm
  */
 function profcond_civicrm_buildForm($formName, &$form) {
-  if ($formName == 'CRM_Event_Form_Registration_Register') {
-    $eventId = $form->get('id');
+  $useConditionals = FALSE;
+  switch ($formName) {
+    case 'CRM_Event_Form_Registration_Register':
+      $useConditionals = 'event';
+      break;
+
+    case 'CRM_Contribute_Form_Contribution_Main':
+      $useConditionals = 'contribution';
+      break;
+  }
+  if ($useConditionals) {
+    $pageId = $form->get('id');
     $config = _profcond_get_search_config();
     // Only take action if we're configured to act on this event.
-    if ($eventConfig = CRM_Utils_Array::value($eventId, $config['event'])) {
+    if ($pageConfig = CRM_Utils_Array::value($pageId, $config[$useConditionals])) {
       CRM_Core_Resources::singleton()->addScriptFile('com.joineryhq.profcond', 'js/profcond.js');
       CRM_Core_Resources::singleton()->addVars('profcond', array(
-        'eventConfig' => $eventConfig,
+        'pageConfig' => $pageConfig,
         'formId' => $form->_attributes['id'],
       ));
       // Add a hidden field for transmitting names of dynamically hidden fields.


### PR DESCRIPTION
This seems to be working pretty well for me - I was able to copy the example config for events to a contribution page and it seemed to handle every case I threw at it.

I used a `switch` statement because I foresee a use for this beyond just event/contribution pages - I recently needed to do something very similar on the "New Activity" page, but I already had an extension ready to do that.  

That will take more work than contribution pages, because the `activity_type_id` can be set in `buildForm` or via a drop-down - also need to handle create and update as separate use cases.  