### PR TITLE
support html attribute; document undocumented css attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ The attribute of the given element to be changed. One of:
 
 * 'display'
 * 'properties'
+* 'css'
+* 'html'
 * 'attributes'
 * 'value'
 * 'before'
@@ -211,6 +213,8 @@ For these values of [state-property], the possible [state-property] values are:
   * 'hide': The element will be hidden with jQuery().hide().
   * 'show': The element will be shown with jQuery().show().
 * 'properties': An associative array of properties, to be applied to the element with jQuery().prop().
+* 'css': An associative array of properties, to be applied to the element with jQuery().css().
+* 'html': An associative array of properties, to be applied to the element with jQuery().html().
 * 'attributes': An associative array of attributes, to be applied to the element with jQuery().attr().
 * 'value': The value to which the element (which should be a form field) will be set, using jQuery().val().
 * 'before': The element will be relocated before the element indicated by this jQuery selector, with jQuery().insertBefore().

--- a/js/profcond.js
+++ b/js/profcond.js
@@ -92,6 +92,9 @@
     if (state.css) {
       el.css(state.css);
     }
+    if (state.html) {
+      el.html(state.html);
+    }
 
     if (typeof state.value != 'undefined') {
       el.val(state.value).change();


### PR DESCRIPTION
This supports using the `html` attribute, which I needed in order to change the title of a profile.

In documenting it I also noticed that the `css` attribute was present but not documented, so I put that in the README as well.