### PR TITLE
Support AdditionalParticipant form for event

### DIFF
--- a/profcond.php
+++ b/profcond.php
@@ -13,6 +13,7 @@ function profcond_civicrm_buildForm($formName, &$form) {
   $useConditionals = FALSE;
   switch ($formName) {
     case 'CRM_Event_Form_Registration_Register':
+    case 'CRM_Event_Form_Registration_AdditionalParticipant':
       $useConditionals = 'event';
       break;
 


### PR DESCRIPTION
Add basic support for `CRM_Event_Form_Registration_AdditionalParticipant`, i.e. the rules that apply to the `CRM_Event_Form_Registration_Register` will also apply to `CRM_Event_Form_Registration_AdditionalParticipant`