### PR TITLE
use label as a subject-identifier-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ or `all_of`, containing any number of conditions.
 One of:
 * id: if the item being evaluated is a DOM element on the page.
 * selector: if the item being evaluated is a DOM element on the page.
+* label: if the item being evaluated is the label of a DOM element on the page.
 * variable: if the item being evaluated is a JavaScript variable. (See "Variables" for
   more information about the JavaScript variables defined by Profile Conditionals.)
 
@@ -199,6 +200,7 @@ One of:
 One of these, depending on the value of [subject-identifier-type]:
 * If [subject-identifier-type] is 'id': The HTML "id" attribute of the field to be tested in this condition.
 * If [subject-identifier-type] is 'selector': A jQuery selector describing the field to be tested in this condition.
+* If [subject-identifier-type] is 'label': A string corresponding to the label of the element to be tested in this condition.
 * If [subject-identifier-type] is 'variable': One of these:
   * String: name of a global variable (property of the window object)
   * Array: ordered array of nested variable names within a global object variable (property of the window object)  

--- a/js/profcond.js
+++ b/js/profcond.js
@@ -273,6 +273,9 @@
       el = $('#' + condition.id);
     } else if (typeof condition.selector != 'undefined') {
       el = $(condition.selector);
+    } else if (typeof condition.label != 'undefined') {
+      condition.id = CRM.$("label:contains(" + condition.label + ")").attr('for');
+      el = $('#' + condition.id);
     }
     return el;
   };


### PR DESCRIPTION
Since I have to unfork my version of the extension anyway, here's the only outstanding feature I have - use label as a subject identifier.

The main use case for this is to show hide the "Other Amount" when someone clicks the "Other" button.  Since the "Other" element has a different ID on each page, this allows you to set the behavior once for all pages (especially future pages).