### PR TITLE
fix client-side required field validation

### DIFF
--- a/js/profcond.js
+++ b/js/profcond.js
@@ -2,6 +2,8 @@
 
   // Define special handler for select2 elements.
   var ps2 = new profcondSelect2($);
+  // Store a list of required fields.
+  var requiredFields = [];
 
   /**
    * Override CiviCRM's calculateTotalFee(); we want to calculate for all
@@ -95,9 +97,15 @@
         switch (state.display) {
           case 'show':
             el.show();
+            el.find('input').each(function() {
+              if (requiredFields.includes(this.id)) {
+                this.classList.add('required');
+              }
+            });
             break;
           case 'hide':
             el.hide();
+            el.find('.required').removeClass('required');
             break;
         }
       }
@@ -319,6 +327,11 @@
   // First thing, add .profcond-price-element class to all price fields, so we can total them
   // with our custom calculateTotalFee() function.
   $("#priceset [price]").addClass('profcond-price-element');
+
+    // Store a list of required fields to better handle jQuery Validate.
+    $('.required').each(function() {
+      requiredFields.push(this.id);
+    });
 
   // Apply default state on page load.
   if (CRM.vars.profcond.pageConfig.onload) {


### PR DESCRIPTION
Here's the fix for jQuery validation of hidden fields.  On page load, we build an array of required fields.  Any time we show an element, we check if any of its descendants were required on page load.  If so, we make them required again.