### PR TITLE
fix scenario with no hidden field names

### DIFF
--- a/profcond.php
+++ b/profcond.php
@@ -85,7 +85,7 @@ function profcond_civicrm_buildForm($formName, &$form) {
         }
         // Now we know the value of profcond_hidden_fields. Temporarily strip them
         // from the "required" array. (We'll add them back later in hook_civicrm_validateForm().)
-        $hiddenFieldNames = array_unique(json_decode($hiddenFieldNamesJson));
+        $hiddenFieldNames = array_unique(json_decode($hiddenFieldNamesJson) ?? []);
         $temporarilyUnrequiredFields = array();
         foreach ($hiddenFieldNames as $hiddenFieldName) {
           $baseHiddenFieldName = $hiddenFieldName;


### PR DESCRIPTION
On PHP 8 I've been getting failures on v1.7.1 when `$hiddenFieldNamesJson` is empty.  Not sure if this is bot activity or legitimate, but no reason not to fix it I suppose.