### PR TITLE
allow 'value_is' with multiple-choice selects

### DIFF
--- a/js/profcond.js
+++ b/js/profcond.js
@@ -275,8 +275,17 @@ CRM.$(function ($, ts) {
       else {
         val = profcondGetConditionValue(condition);
         if (condition.op == 'value_is') {
-          if (val == condition.value) {
-            conditionPass = true;
+          if (Array.isArray(val)) {
+            val.forEach((selectOption) => {
+              if (selectOption == condition.value) {
+                conditionPass = true;
+              }
+            });
+          }
+          else {
+            if (val == condition.value) {
+              conditionPass = true;
+            }
           }
         }
         else if (condition.op == 'value_lt') {


### PR DESCRIPTION
Consider the following scenario. I want the second question to appear if the first question has "Transportation" as an option:
![Selection_2469](https://github.com/user-attachments/assets/16d8174a-675e-4fa8-a7fc-7806d8476dd5)

If I use the following code (`custom_38` is the first question):
```php
        'conditions' => [
          'all_of' => [
            [
              'id' => 'custom_38',
              'op' => 'value_is',
              'value' => '1',
            ],
          ],
        ],
```

Then the condition is only triggered when "Transportation" is the *only* selected option. Otherwise, `profcondGetConditionValue()` returns an array, which will never be equal to `1`.

If question 1 were checkboxes/radio buttons, I could use `is_checked`. And `profcondSelect2.js` exists, but that only applies when the select2 is the `[state-selector]`, not the `[subject-identifier]`.

This PR modifies the `value_is` operator to return `TRUE` if the value is selected in the select2.