### PR TITLE
Support loading an external settings file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ in the sections that follow it.
 This extension has no browser-based configuration form within CiviCRM. Configuration
 is by PHP arrays in code within the civicrm.settings.php file or an external configuration file.
 
-Add your configuration to either civicrm.settings.php, or a file called com.joineryhq.profcond.settings.php in `[civicrm.files]`:
+Add your configuration to either civicrm.settings.php, or a file named com.joineryhq.profcond.settings.php in `[civicrm.files]`:
 ```php
 global $civicrm_setting;
 $civicrm_setting['com.joineryhq.profcond']['com.joineryhq.profcond'] = array(

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ in the sections that follow it.
 ## Configuration
 
 This extension has no browser-based configuration form within CiviCRM. Configuration
-is by PHP arrays in code within the civicrm.settings.php file.
+is by PHP arrays in code within the civicrm.settings.php file or an external configuration file.
 
-You need to add in your civicrm.settings.php a new config variable
+Add your configuration to either civicrm.settings.php, or a file called com.joineryhq.profcond.settings.php in `[civicrm.files]`:
 ```php
 global $civicrm_setting;
 $civicrm_setting['com.joineryhq.profcond']['com.joineryhq.profcond'] = array(

--- a/profcond.php
+++ b/profcond.php
@@ -201,6 +201,14 @@ function profcond_civicrm_enable() {
  *
  */
 function _profcond_get_search_config($pageType, $entityId) {
+  /* If com.joineryhq.profcond.settings.php exists, use it. */
+  $externalPath = $possiblePath = Civi::paths()->getPath("[civicrm.files]/com.joineryhq.profcond.settings.php");
+  if (is_readable($externalPath)) {
+    include_once($externalPath);
+    /* Force the settings manager to reload $civicrm_setting. See note on \Civi\Core\SettingsManager */
+    \Civi::service('settings_manager')->useMandatory();
+  }
+  
   $config = CRM_Core_BAO_Setting::getItem(NULL, 'com.joineryhq.profcond');
   // Invoke hook_civicrm_profcond_alterConfig
   $null = NULL;

--- a/profcond.php
+++ b/profcond.php
@@ -202,7 +202,7 @@ function profcond_civicrm_enable() {
  */
 function _profcond_get_search_config($pageType, $entityId) {
   /* If com.joineryhq.profcond.settings.php exists, use it. */
-  $externalPath = $possiblePath = Civi::paths()->getPath("[civicrm.files]/com.joineryhq.profcond.settings.php");
+  $externalPath = Civi::paths()->getPath("[civicrm.files]/com.joineryhq.profcond.settings.php");
   if (is_readable($externalPath)) {
     include_once($externalPath);
     /* Force the settings manager to reload $civicrm_setting. See note on \Civi\Core\SettingsManager */


### PR DESCRIPTION
Addresses #52 by adding support for loading from `[civicrm.files]/com.joineryhq.profcond.settings.php` for cases where editing the civicrm.settings.php is not possible or ideal:
* The Civi/Joomla installer still recreates civicrm.settings.php
* Some dev site creators (apps that clone a site to a dev site) may recreate civicrm.settings.php based on a template.